### PR TITLE
Allow HTTPS secure protocol for MathJax CDN

### DIFF
--- a/mathjax.html
+++ b/mathjax.html
@@ -12,4 +12,4 @@
             all[i].SourceElement().parentNode.className += ' has-jax';
     });
 </script>
-<script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>


### PR DESCRIPTION
Currently, hexo-renderer-mathjax plugin generates only a insecure (http, not https) link to the MathJax CDN. This causes an issue for Hexo-based static web sites using the https protocol. Major web browsers nowadays emit security warning to viewers if such non-https content links are found on https domain sites.

[MathJax official documentation](http://mathjax.readthedocs.org/en/latest/misc/faq.html#how-do-i-access-the-mathjax-cdn-using-a-https-secure-connection) says, "The MathJax CDN can be accessed via https. We advise to always use https." Making the CDN url start with `//` instead of the usual `http://` allows deployment web servers to automatically switch to either http or https connection when connecting to the MathJax CDN based on the connection protocol type of the hosting sites.
