### PR TITLE
Changed CDN URL due to shut down

### DIFF
--- a/lib/mathjax.html
+++ b/lib/mathjax.html
@@ -12,4 +12,4 @@
             all[i].SourceElement().parentNode.className += ' has-jax';
     });
 </script>
-<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>


### PR DESCRIPTION
https://www.mathjax.org/cdn-shutting-down/